### PR TITLE
chore: 環境変数から取得したnodeをパスに通す

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -976,3 +976,8 @@ vim.opt.expandtab = true
 vim.opt.shiftwidth = 2
 vim.opt.tabstop = 2
 vim.opt.softtabstop = 2
+
+-- Set node path
+if vim.env.NVIM_NODE then
+  vim.env.PATH = vim.env.NVIM_NODE .. ':' .. vim.env.PATH
+end

--- a/lua/custom/plugins/solarized.lua
+++ b/lua/custom/plugins/solarized.lua
@@ -1,13 +1,13 @@
 return {
-  'maxmx03/solarized.nvim',
-  lazy = false,
-  priority = 1000,
-  ---@type solarized.config
-  opts = {},
-  config = function(_, opts)
-    vim.o.termguicolors = true
-    vim.o.background = 'dark'
-    require('solarized').setup(opts)
-    vim.cmd.colorscheme 'solarized'
-  end,
+  --  'maxmx03/solarized.nvim',
+  --  lazy = false,
+  --  priority = 1000,
+  --  ---@type solarized.config
+  --  opts = {},
+  --  config = function(_, opts)
+  --    vim.o.termguicolors = true
+  --    vim.o.background = 'dark'
+  --    require('solarized').setup(opts)
+  --    vim.cmd.colorscheme 'solarized'
+  --  end,
 }


### PR DESCRIPTION
***************************************************************************
**NOTE**
Please verify that the `base repository` above has the intended destination!
Github by default opens Pull Requests against the parent of a forked repository.
If this is your personal fork and you didn't intend to open a PR for contribution
to the original project then adjust the `base repository` accordingly.
**************************************************************************

# 修正概要

自分の環境では、
direnvを利用して、プロジェクトごとにnodeのバージョンを固定している。

この状態で、neovimのgithub copilotプラグインを利用すると、
プロジェクトによっては、nodeのバージョンが古すぎて動作しないことがある。

この問題を解消するために、プロジェクトの環境変数に依存しない形でneovimで利用するnodeのバージョンを固定する。

具体的には、
`.bashrc`等で以下の設定を追記する

```bash
NVIM_NODE = /path/to/node
```

この環境変数が設定されている場合
neovimのPATHにこれを通す用に修正した。

